### PR TITLE
fix: incorrect number replacement

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -2,14 +2,16 @@ import postcss from 'postcss';
 
 export default postcss.plugin('postcss-ic-unit', opts => {
 	const preserve = 'preserve' in Object(opts) ? Boolean(opts.preserve) : true;
+	const whitespace = "[\\f\\n\\r\\x09\\x20]";
+	const icMatch = new RegExp(
+		`((?:\\.\\d+)|\\d+(?:\\.\\d+)?)${whitespace}*ic`,
+		"g"
+	);
 	return root => {
 		root.walkDecls(decl => {
-			if (decl.value.indexOf("ic") === -1) return;
-			if (/\d+ic/.test(decl.value)) {
-				const cloned = decl.cloneBefore();
-				cloned.value = cloned.value.replace(/\d+ic/, string => {
-					return parseInt(string) + 'em'
-				})
+			const replaced = decl.value.replace(icMatch, "$1em");
+			if (replaced !== decl.value) {
+				decl.cloneBefore().value = replaced;
 				if (!preserve) {
 					decl.remove();
 				}

--- a/test/basic.css
+++ b/test/basic.css
@@ -2,4 +2,6 @@ test {
 	text-indent: 2ic;
 	width: calc(8ic + 20px);
 	height: 10px;
+	margin: 0.5ic 1ic .2ic;
+	padding: 2    ic;
 }

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -4,4 +4,8 @@ test {
 	width: calc(8em + 20px);
 	width: calc(8ic + 20px);
 	height: 10px;
+	margin: 0.5em 1em .2em;
+	margin: 0.5ic 1ic .2ic;
+	padding: 2em;
+	padding: 2    ic;
 }

--- a/test/basic.preserve-false.expect.css
+++ b/test/basic.preserve-false.expect.css
@@ -2,4 +2,6 @@ test {
 	text-indent: 2em;
 	width: calc(8em + 20px);
 	height: 10px;
+	margin: 0.5em 1em .2em;
+	padding: 2em;
 }


### PR DESCRIPTION
It should transform `0.5ic`, `2    ic` and `.3ic`.